### PR TITLE
Change filename format of parquet files

### DIFF
--- a/l1a_platform/handlers/l1a_platform.py
+++ b/l1a_platform/handlers/l1a_platform.py
@@ -29,7 +29,7 @@ Event = Dict[str, Any]
 Context = Any
 Getter = Callable[[h5py.File], Dict[str, np.ndarray]]
 
-file_suffix: Dict[Callable, str] = {
+file_prefix: Dict[Callable, str] = {
     get_power_records: "HK_ecPowOps_1",
     get_current_records: "scoCurrentScMode",
     get_temperature_records: "HK_tcThermEssential",
@@ -96,7 +96,7 @@ def read_to_table(getter: Getter, h5_file: h5py.File) -> Optional[pa.Table]:
 
 
 def get_filename(files: List[Path], getter: Getter) -> str:
-    return f"{hash(tuple(files))}_{file_suffix[getter]}" + "_{i}.parquet"
+    return f"{file_prefix[getter]}_{abs(hash(tuple(files)))}" + "_{i}.parquet"
 
 
 def lambda_handler(event: Event, context: Context):

--- a/tests/l1a_platform/handlers/test_l1a_platform.py
+++ b/tests/l1a_platform/handlers/test_l1a_platform.py
@@ -98,7 +98,7 @@ def test_get_filename(getter, extension):
     files = [Path("example.h5"), Path("anotherone.h5")]
 
     fname = get_filename(files, getter)
-    match = re.search(r'([0-9]+_)(.*)(_{i}.parquet)', fname)
+    match = re.search(r'(.*)(_[0-9]+)(_{i}.parquet)', fname)
     assert match is not None
-    assert match[2] == extension
+    assert match[1] == extension
     assert match[3] == "_{i}.parquet"


### PR DESCRIPTION
This changes the filename format of written parquet files from
`{hash}_{package_name}_{i}.parquet`
to
`{package_name}_{abs(hash)}_{i}.parquet`

which makes it easier to open only the packages of interest with pyarrow and removes the annoyance of getting hashed names that starts with `-`