### PR TITLE
Write afsTangentPoint to orbit records

### DIFF
--- a/l1a_platform/handlers/records.py
+++ b/l1a_platform/handlers/records.py
@@ -166,9 +166,6 @@ def get_attitude_records(h5_file: h5py.File) -> Dict[str, np.ndarray]:
         AttitudeRecord.spacecraft_rate.out_name: np.array(
             h5_file[AttitudeRecord.spacecraft_rate.path]
         ).T.tolist(),
-        AttitudeRecord.tangent_point.out_name: np.array(
-            h5_file[AttitudeRecord.tangent_point.path]
-        ).T.tolist(),
     }
 
 
@@ -181,7 +178,12 @@ def get_orbit_records(h5_file: h5py.File) -> Dict[str, np.ndarray]:
         OrbitRecord.gnss_state.out_name: gnss.tolist(),
         OrbitRecord.navigation_uncertainty.out_name: (
             uncertainty[np.newaxis, :, :].repeat(len(time), axis=0).tolist()
-        )
+        ),
+        #  AttitudeRecord.tangent_point is added here due to having its time
+        #  axis shared with orbit records rather than attitude records.
+        AttitudeRecord.tangent_point.out_name: np.array(
+            h5_file[AttitudeRecord.tangent_point.path]
+        ).T.tolist(),
     }
 
 

--- a/tests/l1a_platform/handlers/test_records.py
+++ b/tests/l1a_platform/handlers/test_records.py
@@ -44,7 +44,6 @@ def test_get_attitude_records(h5_file):
     assert np.array(data["afsAttitudeUncertainty"]).shape == (63, 3, 3)
     assert np.array(data["afsRateUncertainty"]).shape == (63, 3, 3)
     assert np.array(data["afsSpacecraftRate"]).shape == (63, 3)
-    assert np.array(data["afsTangentPoint"]).shape == (63, 3)
 
 
 def test_get_orbit_records(h5_file):
@@ -52,6 +51,7 @@ def test_get_orbit_records(h5_file):
     assert data["time"].shape == (63,)
     assert np.array(data["acsGnssStateJ2000"]).shape == (63, 6)
     assert np.array(data["acsNavigationUncertainty"]).shape == (63, 6, 6)
+    assert np.array(data["afsTangentPoint"]).shape == (63, 3)
 
 
 def test_get_gnss_records(h5_file):


### PR DESCRIPTION
`afsTangentPoint` in `AttitudeRecords` is instead written to `OrbitRecords` since it has a time axis that matches (better).