### PR TITLE
Handle single files and write to new folder structure

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ L1APlatformStack(
     app,
     "L1APlatformToParquetStack",
     input_bucket_name="ops-platform-level1a-source",
-    output_bucket_name="ops-platform-level1a-v0.1",
+    output_bucket_name="ops-platform-level1a-v0.2",
     queue_arn_export_name="L0PlatformFetcherStackOutputQueue",
 )
 

--- a/l1a_platform/handlers/l1a_platform.py
+++ b/l1a_platform/handlers/l1a_platform.py
@@ -75,12 +75,7 @@ def download_file(
     output_dir: TemporaryDirectory,
 ) -> Path:
     file_path = Path(f"{output_dir.name}/{file_name}")
-    with open(file_path, "wb") as h5_file:
-        s3_client.download_fileobj(
-            bucket_name,
-            file_name,
-            h5_file,
-        )
+    s3_client.download_file(bucket_name, file_name, file_path)
     return file_path
 
 

--- a/l1a_platform/handlers/l1a_platform.py
+++ b/l1a_platform/handlers/l1a_platform.py
@@ -4,7 +4,7 @@ import logging
 import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple
 
 import boto3
 import h5py  # type: ignore
@@ -29,7 +29,7 @@ Event = Dict[str, Any]
 Context = Any
 Getter = Callable[[h5py.File], Dict[str, np.ndarray]]
 
-file_prefix: Dict[Callable, str] = {
+folder_prefix: Dict[Callable, str] = {
     get_power_records: "HK_ecPowOps_1",
     get_current_records: "scoCurrentScMode",
     get_temperature_records: "HK_tcThermEssential",
@@ -52,11 +52,11 @@ def get_or_raise(variable_name: str) -> str:
     return var
 
 
-def parse_event_message(event: Event) -> Tuple[List[str], str]:
+def parse_event_message(event: Event) -> Tuple[str, str]:
     message: Dict[str, Any] = json.loads(event["Records"][0]["body"])
+    object = message["object"]
     bucket = message["bucket"]
-    objects = message["objects"]
-    return objects, bucket
+    return object, bucket
 
 
 def get_partitioned_dates(datetimes: np.ndarray) -> Dict[str, np.ndarray]:
@@ -68,23 +68,20 @@ def get_partitioned_dates(datetimes: np.ndarray) -> Dict[str, np.ndarray]:
     }
 
 
-def download_files(
+def download_file(
     s3_client: S3Client,
     bucket_name: str,
-    file_names: List[str],
+    file_name: str,
     output_dir: TemporaryDirectory,
-) -> List[Path]:
-    out_files = []
-    for file_name in file_names:
-        file_path = Path(f"{output_dir.name}/{file_name}")
-        with open(file_path, "wb") as h5_file:
-            s3_client.download_fileobj(
-                bucket_name,
-                file_name,
-                h5_file,
-            )
-            out_files.append(file_path)
-    return out_files
+) -> Path:
+    file_path = Path(f"{output_dir.name}/{file_name}")
+    with open(file_path, "wb") as h5_file:
+        s3_client.download_fileobj(
+            bucket_name,
+            file_name,
+            h5_file,
+        )
+    return file_path
 
 
 def read_to_table(getter: Getter, h5_file: h5py.File) -> Optional[pa.Table]:
@@ -99,21 +96,19 @@ def read_to_table(getter: Getter, h5_file: h5py.File) -> Optional[pa.Table]:
     return None
 
 
-def get_filename(files: List[Path], getter: Getter) -> str:
-    return f"{file_prefix[getter]}_{abs(hash(tuple(files)))}" + "_{i}.parquet"
+def get_filename(h5_filename: str) -> str:
+    return h5_filename.removesuffix(".h5") + "_{i}.parquet"
 
 
 def lambda_handler(event: Event, context: Context):
     out_bucket = get_or_raise("OUTPUT_BUCKET")
     region = os.environ.get('AWS_REGION', "eu-north-1")
-    objects, in_bucket = parse_event_message(event)
-    if objects == []:
-        raise NothingToDo
+    object, in_bucket = parse_event_message(event)
     tempdir = TemporaryDirectory()
 
     s3_client = boto3.client('s3')
-    files = download_files(s3_client, in_bucket, objects, tempdir)
-    h5_files = [h5py.File(h5_file_path) for h5_file_path in files]
+    file = download_file(s3_client, in_bucket, object, tempdir)
+    h5_file = h5py.File(file)
 
     for f in (
         get_power_records,
@@ -124,26 +119,22 @@ def lambda_handler(event: Event, context: Context):
         get_gnss_records,
         get_hirate_attitude_records,
     ):
-        tables: List[h5py.Table] = list(filter(None, [
-            read_to_table(f, h5) for h5 in h5_files
-        ]))
-        if len(tables) > 0:
-            pq.write_to_dataset(
-                table=tables,
-                root_path=out_bucket,
-                basename_template=get_filename(files, f),
-                existing_data_behavior="overwrite_or_ignore",
-                filesystem=pa.fs.S3FileSystem(
-                    region=region,
-                    request_timeout=10,
-                    connect_timeout=10
-                ),
-                partitioning=ds.partitioning(
-                    schema=pa.schema([
-                        ('year', pa.int32()),
-                        ('month', pa.int32()),
-                        ('day', pa.int32()),
-                    ]),
-                ),
-                version='2.6',
-            )
+        pq.write_to_dataset(
+            table=read_to_table(f, h5_file),
+            root_path=f"{out_bucket}/{folder_prefix[f]}",
+            basename_template=get_filename(object),
+            existing_data_behavior="overwrite_or_ignore",
+            filesystem=pa.fs.S3FileSystem(
+                region=region,
+                request_timeout=10,
+                connect_timeout=10
+            ),
+            partitioning=ds.partitioning(
+                schema=pa.schema([
+                    ('year', pa.int32()),
+                    ('month', pa.int32()),
+                    ('day', pa.int32()),
+                ]),
+            ),
+            version='2.6',
+        )

--- a/tests/l1a_platform/handlers/test_l1a_platform.py
+++ b/tests/l1a_platform/handlers/test_l1a_platform.py
@@ -64,7 +64,7 @@ def test_download_file():
     file_name = "file1"
     output_dir = TemporaryDirectory()
     download_file(mocked_client, bucket_name, file_name, output_dir)
-    mocked_client.download_fileobj.assert_called_once_with(
+    mocked_client.download_file.assert_called_once_with(
         'bucket',
         'file1',
         ANY,


### PR DESCRIPTION
Part of #14

- Expect a single `object` rather than multiple `objects`
- Write partitioned parquet dataset with names same as the `.h5` file it was read from
- Split the output dataset by folder prefix in the same way that was done in the RAC-pipeline 

Will create a new version of the platform-data bucket and make a rerun when deploying this