### PR TITLE
Skip groups

### DIFF
--- a/l1a_platform/handlers/l1a_platform.py
+++ b/l1a_platform/handlers/l1a_platform.py
@@ -132,4 +132,4 @@ def lambda_handler(event: Event, context: Context):
                 version='2.6',
             )
         except Exception as err:
-            print(f"Could not write group {f}: {err}")
+            print(f"Could not write group {f} from {file.name}: {err}")

--- a/l1a_platform/handlers/l1a_platform.py
+++ b/l1a_platform/handlers/l1a_platform.py
@@ -111,22 +111,25 @@ def lambda_handler(event: Event, context: Context):
         get_acs_slow_ops_records,
         get_acs_fast_ops_records,
     ):
-        pq.write_to_dataset(
-            table=read_to_table(f, h5_file),
-            root_path=f"{out_bucket}/{folder_prefix[f]}",
-            basename_template=get_filename(object),
-            existing_data_behavior="overwrite_or_ignore",
-            filesystem=pa.fs.S3FileSystem(
-                region=region,
-                request_timeout=10,
-                connect_timeout=10
-            ),
-            partitioning=ds.partitioning(
-                schema=pa.schema([
-                    ('year', pa.int32()),
-                    ('month', pa.int32()),
-                    ('day', pa.int32()),
-                ]),
-            ),
-            version='2.6',
-        )
+        try:
+            pq.write_to_dataset(
+                table=read_to_table(f, h5_file),
+                root_path=f"{out_bucket}/{folder_prefix[f]}",
+                basename_template=get_filename(object),
+                existing_data_behavior="overwrite_or_ignore",
+                filesystem=pa.fs.S3FileSystem(
+                    region=region,
+                    request_timeout=10,
+                    connect_timeout=10
+                ),
+                partitioning=ds.partitioning(
+                    schema=pa.schema([
+                        ('year', pa.int32()),
+                        ('month', pa.int32()),
+                        ('day', pa.int32()),
+                    ]),
+                ),
+                version='2.6',
+            )
+        except Exception as err:
+            print(f"Could not write group {f}: {err}")


### PR DESCRIPTION
This skips groups if not existing, rather than failing file. The missing groups are output to logs.

Resolves #20, though we may need to add something to the l1a-lambda as well, if this is not enough.